### PR TITLE
Issue openam#36 Remove dependency on ForgeRock Maven repositories

### DIFF
--- a/persistit-core/pom.xml
+++ b/persistit-core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.forgerock.commons</groupId>
     <artifactId>forgerock-persistit</artifactId>
-    <version>4.3.1</version>
+    <version>4.3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>forgerock-persistit-core</artifactId>

--- a/persistit-core/pom.xml
+++ b/persistit-core/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.forgerock.commons</groupId>
+    <groupId>jp.openam.commons</groupId>
     <artifactId>forgerock-persistit</artifactId>
     <version>4.3.2-SNAPSHOT</version>
   </parent>

--- a/persistit-ui/pom.xml
+++ b/persistit-ui/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.forgerock.commons</groupId>
     <artifactId>forgerock-persistit</artifactId>
-    <version>4.3.1</version>
+    <version>4.3.2-SNAPSHOT</version>
   </parent>
 
   <artifactId>forgerock-persistit-ui</artifactId>

--- a/persistit-ui/pom.xml
+++ b/persistit-ui/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.forgerock.commons</groupId>
+    <groupId>jp.openam.commons</groupId>
     <artifactId>forgerock-persistit</artifactId>
     <version>4.3.2-SNAPSHOT</version>
   </parent>
@@ -15,7 +15,7 @@
 
   <dependencies>
     <dependency>
-       <groupId>org.forgerock.commons</groupId>
+       <groupId>jp.openam.commons</groupId>
       <artifactId>forgerock-persistit-core</artifactId>
       <version>${project.version}</version>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>jp.openam</groupId>
     <artifactId>forgerock-parent</artifactId>
-    <version>2.0.3</version>
+    <version>2.0.7-SNAPSHOT</version>
   </parent>
 
   <groupId>jp.openam.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,11 +16,11 @@
   <name>ForgeRock Persistit</name>
   <description>Java B+Tree Key-Value Store Library</description>
   <inceptionYear>2005</inceptionYear>
-  <url>https://stash.forgerock.org/projects/COMMONS/repos/forgerock-persistit</url>
+  <url>https://github.com/openam-jp/forgerock-persistit</url>
 
   <organization>
-    <name>ForgeRock</name>
-    <url>http://www.forgerock.com</url>
+    <name>OpenAM Consortium</name>
+    <url>https://www.openam.jp/</url>
   </organization>
 
   <modules>
@@ -37,35 +37,10 @@
   </licenses>
 
   <scm>
-    <developerConnection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-persistit.git</developerConnection>
-    <connection>scm:git:ssh://git@stash.forgerock.org:7999/commons/forgerock-persistit.git</connection>
-    <url>https://stash.forgerock.org/projects/COMMONS/repos/forgerock-persistit/browse</url>
-    <tag>4.3.1</tag>
+    <developerConnection>scm:git:https://github.com/openam-jp/forgerock-persistit.git</developerConnection>
+    <connection>scm:git:git@github.com:openam-jp/forgerock-persistit.git</connection>
+    <url>https://github.com/openam-jp/forgerock-persistit</url>
   </scm>
-
-  <distributionManagement>
-    <snapshotRepository>
-      <id>forgerock-snapshots</id>
-      <name>ForgeRock Snapshot Repository</name>
-      <url>${forgerockDistMgmtSnapshotsUrl}</url>
-    </snapshotRepository>
-    <repository>
-      <id>forgerock-staging</id>
-      <name>ForgeRock Release Repository</name>
-      <url>${forgerockDistMgmtReleasesUrl}</url>
-    </repository>
-  </distributionManagement>
-  
-  <repositories>
-    <repository>
-      <id>forgerock-staging-repository</id>
-      <name>ForgeRock Release Repository</name>
-      <url>${forgerockDistMgmtReleasesUrl}</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
 
   <properties>
     <!-- To configure animal-sniffer to check API compat -->
@@ -74,8 +49,6 @@
     <animal-sniffer.signature.version>1.0</animal-sniffer.signature.version>
     <version.animal-sniffer.plugin>1.11</version.animal-sniffer.plugin>
     <version.maven-license.plugin>2.6</version.maven-license.plugin>
-    <forgerockDistMgmtSnapshotsUrl>http://maven.forgerock.org/repo/snapshots</forgerockDistMgmtSnapshotsUrl>
-    <forgerockDistMgmtReleasesUrl>http://maven.forgerock.org/repo/releases</forgerockDistMgmtReleasesUrl>
   </properties>
 
   <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.forgerock.commons</groupId>
   <artifactId>forgerock-persistit</artifactId>
-  <version>4.3.1</version>
+  <version>4.3.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>ForgeRock Persistit</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>org.forgerock</groupId>
+    <groupId>jp.openam</groupId>
     <artifactId>forgerock-parent</artifactId>
     <version>2.0.3</version>
   </parent>
 
-  <groupId>org.forgerock.commons</groupId>
+  <groupId>jp.openam.commons</groupId>
   <artifactId>forgerock-persistit</artifactId>
   <version>4.3.2-SNAPSHOT</version>
   <packaging>pom</packaging>


### PR DESCRIPTION
## Analysis
This project is B+Tree Key-Value Store Library for OpenDJ backend.

In order to fix openam-jp/openam#36, this project also needs modification.

## Solution

* Remove ForgeRock repository tags in pom.xml
* Change Maven groupId
* Adjust maven dependency

## Install/Update
N/A

## Compatibility
N/A

## Performance
N/A

## I18N
N/A

## Testing
```
$ mvn install -f forgerock-parent
$ mvn install -f forgerock-build-tools
$ mvn install -DskipTests -f forgerock-persistit
```

Due to some problems, this project needs to skip unit testing(see #1).

## Regression testing
N/A