### PR TITLE
Issue openam#32 Support Java 11 (OpenJDK 11)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
     <animal-sniffer.signature.groupId>org.codehaus.mojo.signature</animal-sniffer.signature.groupId>
     <animal-sniffer.signature.artifactId>java17</animal-sniffer.signature.artifactId>
     <animal-sniffer.signature.version>1.0</animal-sniffer.signature.version>
-    <version.animal-sniffer.plugin>1.11</version.animal-sniffer.plugin>
+    <version.animal-sniffer.plugin>1.18</version.animal-sniffer.plugin>
     <version.maven-license.plugin>2.6</version.maven-license.plugin>
   </properties>
 
@@ -129,7 +129,14 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>rmic-maven-plugin</artifactId>
-          <version>1.0</version>
+          <version>1.3</version>
+          <dependencies>
+              <dependency>
+                  <groupId>org.glassfish.corba</groupId>
+                  <artifactId>rmic</artifactId>
+                  <version>4.2.1</version>
+              </dependency>
+          </dependencies>
           <configuration>
             <outputDirectory>target/classes/</outputDirectory>
           </configuration>


### PR DESCRIPTION
## Analysis
openam-jp/openam#32

OpenAM now supports Java8.

While Java 8 is supported by various vendors, but public updates of Oracle Java will close soon.
Also, since release 9, the release model has changed.

OpenAM needs to support Java 11, the latest long-term support Java version.

## Solution
Support Java 11 (OpenJDK 11) as development environment and execution environment.

## Install/Update
Dependency effects are also occurring in other projects.
Obtain the source with modified dependencies in the following order and build
- forgerock-bom
- forgerock-build-tools
- forgerock-i18n-framework
- forgerock-guice
- forgerock-ui
- forgerock-guava
- forgerock-commons
- forgerock-persistit
- opendj-sdk
- opendj
- openam
